### PR TITLE
Удалены нерабочие ссылки из описания метода users.getHolidays

### DIFF
--- a/docs/method/ru/users/users.getHolidays.md
+++ b/docs/method/ru/users/users.getHolidays.md
@@ -1,7 +1,7 @@
 users.getHolidays
 
 $description
-Метод позволяет получать список праздников пользователя. См. также {% replace_method users.getFriendsHolidays %} и {% replace_method users.getPortalHolidays %}.
+Метод позволяет получать список праздников пользователя.
 
 $params#uid
 Идентификатор пользователя, чьи праздники требуется получить. 


### PR DESCRIPTION
Документация для методов users.getFriendsHolidays и users.getPortalHolidays отсутствует, ссылки ведут на несуществующие страницы.